### PR TITLE
fix on my logo mistake loading screen

### DIFF
--- a/client/src/components/LoadingScreen/LoadingScreen.js
+++ b/client/src/components/LoadingScreen/LoadingScreen.js
@@ -76,9 +76,6 @@ class LoadingScreen extends Component {
                     
         <p>{this.state.pendingMessage}</p>
 
-        <img src={gif} alt="" className="loading-gif"/>
-                
-
         <div>
           <img src={gif} alt="" className="loading-gif"/>
           {this.state.members.length ? (


### PR DESCRIPTION
accidently had the logo showing twice in the loading screen due to my playing around with things. fixed!